### PR TITLE
separator parameter included (s). default value '.'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+*.*~
+*.pyc
+*.log
+*.pyc
+*.DS_Store
+*.directory
+*.sql
+*.xls
+*.p12
+*.cer
+*.pem
+*.egg-info
+
+.project
+.pydevproject
+
+.idea

--- a/flatten_json/flatten_json.py
+++ b/flatten_json/flatten_json.py
@@ -1,14 +1,14 @@
-def flatten_json(y):
+def flatten_json(y, s='.'):
     out = {}
 
     def flatten(x, name=''):
         if type(x) is dict:
             for a in x:
-                flatten(x[a], name + a + '_')
+                flatten(x[a], name + a + s)
         elif type(x) is list:
             i = 0
             for a in x:
-                flatten(a, name + str(i) + '_')
+                flatten(a, name + str(i) + s)
                 i += 1
         else:
             a = ''
@@ -17,7 +17,7 @@ def flatten_json(y):
             except:
                 a = x.encode('ascii', 'ignore').decode('ascii')
             
-            out[str(name[:-1])] = a
+            out[str(name[:-len(s)])] = a
 
     flatten(y)
     return out


### PR DESCRIPTION
I think that it is more flexible if the separator can be fixed as a parameter
I named it as 's' and fixed it to '.' as its default value. I mean:

`def flatten_json(y, s='.'):`

All the best!
