### PR TITLE
Added unflatten with list capability as a separator function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Thanks to [@jvalhondo](http://github.com/jvalhondo), [@drajen](http://github.com
 ### Unflatten
 Reverses the flattening process. Example usage:
 ```python
+from flatten_json import unflatten
+
 dic = {
     'a': 1,
     'b_a': 2,
@@ -97,12 +99,37 @@ returns:
 }
 ```
 
-**Note**
-Currently this feature does not properly handle lists. `flatten` encodes key for list values with integer indices which makes it ambiguous for reversing the process. Consider this flattened dictionary:
+### Unflatten with lists
+`flatten` encodes key for list values with integer indices which makes it ambiguous for reversing the process. Consider this flattened dictionary:
 ```python
 a = {'a': 1, 'b_0': 5}
 ```
 
-Both `{'a': 1, 'b': [5]}` and `{'a': 1, 'b': {0: 5}}` are legitimate answers. For now this function is going to output the latter. Feel free to take this. If you do make sure you can passs the `test_unflatten_with_list` test which is currently failing. 
+Both `{'a': 1, 'b': [5]}` and `{'a': 1, 'b': {0: 5}}` are legitimate answers.
+ 
+Calling `unflatten_list` the dictionary is first unflattened and then in a post-processing step the function looks for a list pattern (zero-indexed consecutive integer keys) and transforms the matched values into a list.
+ 
+Here's an example:
+```python
+from flatten_json import unflatten_list
+dic = {
+    'a': 1,
+    'b_0': 1,
+    'b_1': 2,
+    'c_a': 'a',
+    'c_b_0': 1,
+    'c_b_1': 2,
+    'c_b_2': 3
+}
+unflatten_list(dic)
+```
+returns:
+```python
+{
+    'a': 1,
+    'b': [1, 2],
+    'c': {'a': 'a', 'b': [1, 2, 3]}
+}
+```
 
 Thanks to [@nmaas87](http://github.com/nmaas87) for requesting this feature.

--- a/flatten_json.py
+++ b/flatten_json.py
@@ -1,5 +1,7 @@
 from collections import Iterable
 
+from util import check_if_numbers_are_consecutive
+
 
 def _construct_key(previous_key, separator, new_key):
     """
@@ -50,17 +52,22 @@ def flatten(nested_dict, separator="_"):
 flatten_json = flatten
 
 
+def _unflatten_asserts(flat_dict, separator):
+    assert isinstance(flat_dict, dict), "un_flatten requires a dictionary input"
+    assert isinstance(separator, str), "separator must be a string"
+    assert all((not isinstance(value, Iterable) or isinstance(value, str)
+                for value in flat_dict.values())), "provided dictionary is not flat"
+
+
 def unflatten(flat_dict, separator='_'):
     """
-    Creates a hierachical dictionary from a flattened dictionary
+    Creates a hierarchical dictionary from a flattened dictionary
     Assumes that no lists are present in the
     :param flat_dict: a dictionary with no hierarchy
     :param separator: a string that separates keys
     :return: a dictionary with hierarchy
     """
-    assert isinstance(flat_dict, dict), "un_flatten requires a dictionary input"
-    assert isinstance(separator, str), "separator must be a string"
-    assert all((not isinstance(value, Iterable) for value in flat_dict.values())), "provided dictionary is not flat"
+    _unflatten_asserts(flat_dict, separator)
 
     # This global dictionary is mutated and returned
     unflattened_dict = dict()
@@ -74,4 +81,40 @@ def unflatten(flat_dict, separator='_'):
     for item in flat_dict:
         _unflatten(unflattened_dict, item.split(separator), flat_dict[item])
 
+    return unflattened_dict
+
+
+def unflatten_list(flat_dict, separator='_'):
+    """
+    Unflattens a dictionary, first assuming no lists exist and then tries to identify lists and replace them
+    This is probably not very inefficient and has not been tested extensively
+    Feel free to add test cases or rewrite the logic
+    Issues that stand out to me:
+    - Sorting all the keys in the dictionary, which specially for the root dictionary can be a lot of keys
+    - Checking that numbers are consecutive is O(N) in number of keys
+
+    :param flat_dict: dictionary with no hierarchy
+    :param separator: a string that separates keys
+    :return: a dictionary with hierarchy
+    """
+    _unflatten_asserts(flat_dict, separator)
+
+    # First unflatten the dictionary assuming no lists exist
+    unflattened_dict = unflatten(flat_dict)
+
+    def _convert_dict_to_list(object_, parent_object, parent_object_key):
+        if isinstance(object_, dict):
+            try:
+                keys = [int(key) for key in sorted(object_) if
+                        not isinstance(object_[key], Iterable) or isinstance(object_[key], str)]
+                keys_len = len(keys)
+                if (sum(keys) == int(((keys_len - 1) * keys_len) / 2) and keys[0] == 0 and keys[-1] == keys_len - 1 and
+                        check_if_numbers_are_consecutive(keys)):
+                    parent_object[parent_object_key] = [object_[str(key)] for key in keys]
+            except (ValueError, TypeError):
+                for key in object_:
+                    if isinstance(object_[key], dict):
+                        _convert_dict_to_list(object_[key], object_, key)
+
+    _convert_dict_to_list(unflattened_dict, None, None)
     return unflattened_dict

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -1,9 +1,32 @@
 import unittest
 
-from flatten_json import flatten, unflatten
+from flatten_json import flatten, unflatten, unflatten_list
+from util import check_if_numbers_are_consecutive
 
 
 class UnitTests(unittest.TestCase):
+    def test_numbers_consecutive(self):
+        """Checks if all numbers in a list are consecutive integers"""
+        list_ = [1, 2, 3, 4, 5]
+        actual = check_if_numbers_are_consecutive(list_)
+        self.assertTrue(actual)
+
+        list_ = [0, 1, 5]
+        actual = check_if_numbers_are_consecutive(list_)
+        self.assertFalse(actual)
+
+        list_ = [1.0, 2.0, 3.0]
+        actual = check_if_numbers_are_consecutive(list_)
+        self.assertTrue(actual)
+
+        list_ = range(10)
+        actual = check_if_numbers_are_consecutive(list_)
+        self.assertTrue(actual)
+
+        list_ = range(10, 0, -1)
+        actual = check_if_numbers_are_consecutive(list_)
+        self.assertFalse(actual)
+
     def test_no_flatten(self):
         dic = {'a': '1', 'b': '2', 'c': 3}
         expected = dic
@@ -74,21 +97,27 @@ class UnitTests(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_unflatten_with_list(self):
-        """This test is currently failing, unflatten is not handling lists properly"""
+        """Dictionary with lists"""
         dic = {
             'a': 1,
             'b_0': 1,
             'b_1': 2,
             'c_a': 'a',
             'c_b_0': 1,
-            'c_b_1': 2
+            'c_b_1': 2,
+            'c_b_2': 3
         }
         expected = {
             'a': 1,
             'b': [1, 2],
-            'c': {'a': 'a', 'b': [1, 2]}
+            'c': {'a': 'a', 'b': [1, 2, 3]}
         }
-        actual = unflatten(dic)
+        actual = unflatten_list(dic)
+        self.assertEqual(actual, expected)
+
+        dic = {'a': 1, 'b_0': 5}
+        expected = {'a': 1, 'b': [5]}
+        actual = unflatten_list(dic)
         self.assertEqual(actual, expected)
 
 if __name__ == '__main__':

--- a/util.py
+++ b/util.py
@@ -1,0 +1,9 @@
+def check_if_numbers_are_consecutive(list_):
+    """
+    Returns True if numbers in the list are consecutive
+
+    :param list_: list of integers
+    :return: Boolean
+    """
+    return all([True if second - first == 1 else False
+                for first, second in zip(list_[:-1], list_[1:])])


### PR DESCRIPTION
### Summary
Added unflattening with list capabilities. This is currently a separate API and calls `unflatten` as the first step. I decided to make this a separate function since it requires more processing and may not always be desired. `unflatten_list` first creates a hierarchical dictionary and then looks for list patterns inside the hierarchy and transforms those into lists. 

### Bug Fixes/New Features
* Supports unflattening with lists

### How to Verify
Passing `test_unflatten_with_list` that I wrote earlier. Feel free to suggest new tests.

### Side Effects
No

### Resolves
https://github.com/amirziai/flatten/issues/4

### Tests
Added tests for `unflatten_list` and a new utility function that supports it

### Code Reviewer(s)
@nmaas87