### PR TITLE
Unflatten list separator

### DIFF
--- a/flatten_json.py
+++ b/flatten_json.py
@@ -100,7 +100,7 @@ def unflatten_list(flat_dict, separator='_'):
     _unflatten_asserts(flat_dict, separator)
 
     # First unflatten the dictionary assuming no lists exist
-    unflattened_dict = unflatten(flat_dict)
+    unflattened_dict = unflatten(flat_dict, separator)
 
     def _convert_dict_to_list(object_, parent_object, parent_object_key):
         if isinstance(object_, dict):

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -120,5 +120,10 @@ class UnitTests(unittest.TestCase):
         actual = unflatten_list(dic)
         self.assertEqual(actual, expected)
 
+        dic = {'a': 1, 'b:0': 5}
+        expected = {'a': 1, 'b': [5]}
+        actual = unflatten_list(dic, ':')
+        self.assertEqual(actual, expected)        
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary
`unflatten_list` did not pass the custom separator, when calling `unflatten` internally

### Bug Fixes
* `unflatten_list` works with custom separator

### Tests
Added test case, run pytest.