### PR TITLE
Unflatten list does not work with more complex cases

### DIFF
--- a/flatten_json.py
+++ b/flatten_json.py
@@ -104,17 +104,19 @@ def unflatten_list(flat_dict, separator='_'):
 
     def _convert_dict_to_list(object_, parent_object, parent_object_key):
         if isinstance(object_, dict):
+            keys = []
             try:
-                keys = [int(key) for key in sorted(object_) if
-                        not isinstance(object_[key], Iterable) or isinstance(object_[key], str)]
-                keys_len = len(keys)
-                if (sum(keys) == int(((keys_len - 1) * keys_len) / 2) and keys[0] == 0 and keys[-1] == keys_len - 1 and
-                        check_if_numbers_are_consecutive(keys)):
-                    parent_object[parent_object_key] = [object_[str(key)] for key in keys]
+                keys = [int(key) for key in object_]
+                keys.sort()
             except (ValueError, TypeError):
-                for key in object_:
-                    if isinstance(object_[key], dict):
-                        _convert_dict_to_list(object_[key], object_, key)
+                pass
+            keys_len = len(keys)
+            if (keys_len and sum(keys) == int(((keys_len - 1) * keys_len) / 2) and keys[0] == 0 and
+                    keys[-1] == keys_len - 1 and check_if_numbers_are_consecutive(keys)):
+                parent_object[parent_object_key] = [object_[str(key)] for key in keys]
+            for key in object_:
+                if isinstance(object_[key], dict):
+                    _convert_dict_to_list(object_[key], object_, key)
 
     _convert_dict_to_list(unflattened_dict, None, None)
     return unflattened_dict

--- a/flatten_json.py
+++ b/flatten_json.py
@@ -104,12 +104,11 @@ def unflatten_list(flat_dict, separator='_'):
 
     def _convert_dict_to_list(object_, parent_object, parent_object_key):
         if isinstance(object_, dict):
-            keys = []
             try:
                 keys = [int(key) for key in object_]
                 keys.sort()
             except (ValueError, TypeError):
-                pass
+                keys = []
             keys_len = len(keys)
             if (keys_len and sum(keys) == int(((keys_len - 1) * keys_len) / 2) and keys[0] == 0 and
                     keys[-1] == keys_len - 1 and check_if_numbers_are_consecutive(keys)):

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -123,7 +123,44 @@ class UnitTests(unittest.TestCase):
         dic = {'a': 1, 'b:0': 5}
         expected = {'a': 1, 'b': [5]}
         actual = unflatten_list(dic, ':')
-        self.assertEqual(actual, expected)        
+        self.assertEqual(actual, expected)
+
+    def test_unflatten_with_list_custom_separator(self):
+        """Complex dictionary with lists"""
+        self.maxDiff = None
+        dic = {
+            'a:b': 'str0',
+            'c:0:d:0:e': 'str1',
+            'c:0:f': 'str2',
+            'c:0:g': 'str3',
+            'c:1:d:0:e': 'str4',
+            'c:1:f': 'str5',
+            'c:1:g': 'str6',
+            'h:d:0:e': 'str7',
+            'h:i:0:f': 'str8',
+            'h:i:0:g': 'str9'
+        }
+        expected = {
+            'a': {'b': 'str0'},
+            'c': [
+                {
+                    'd': [{'e': 'str1'}],
+                    'f': 'str2',
+                    'g': 'str3'
+                }, {
+                    'd': [{'e': 'str4'}],
+                    'f': 'str5',
+                    'g': 'str6'
+                }
+            ],
+            'h': {
+                'd': [{'e': 'str7'}],
+                'i': [{'f': 'str8', 'g': 'str9'}]
+            }
+        }
+        actual = unflatten_list(dic, ':')
+        self.assertEqual(actual, expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -127,7 +127,6 @@ class UnitTests(unittest.TestCase):
 
     def test_unflatten_with_list_custom_separator(self):
         """Complex dictionary with lists"""
-        self.maxDiff = None
         dic = {
             'a:b': 'str0',
             'c:0:d:0:e': 'str1',

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -131,11 +131,11 @@ class UnitTests(unittest.TestCase):
         dic = {
             'a:b': 'str0',
             'c:0:d:0:e': 'str1',
-            'c:0:f': 'str2',
-            'c:0:g': 'str3',
             'c:1:d:0:e': 'str4',
             'c:1:f': 'str5',
+            'c:0:f': 'str2',
             'c:1:g': 'str6',
+            'c:0:g': 'str3',
             'h:d:0:e': 'str7',
             'h:i:0:f': 'str8',
             'h:i:0:g': 'str9'


### PR DESCRIPTION
### Summary
Unflatten list does not work with more complex cases. Changed the algorithm to dig in the recursion for each key.

### Bug Fixes/New Features
* More complex structures are not unflattened correctly

### How to Verify
pytest

### Resolves
Fixes  #8 

### Tests
Added `test_unflatten_with_list_custom_separator` test case

### Code Reviewer(s)
@amirziai 