### PR TITLE
Flatten ignore keys#9

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Flattens JSON objects in Python. ```flatten_json``` destroys the hierarchy in yo
 pip install flatten_json
 ```
 
+# flatten
+
 ### Usage
 Let's say you have the following object:
 ```python
@@ -78,8 +80,30 @@ returns:
 
 Thanks to [@jvalhondo](http://github.com/jvalhondo), [@drajen](http://github.com/drajen), and [@azaitsev](http://github.com/azaitsev) for contributing to this feature.
 
+### Ignore root keys
+By default `flatten` goes through all the keys in the object. If you are not interested in output from a set of keys you can pass this set as an argument to `root_keys_to_ignore`.:
 
-### Unflatten
+```python
+dic = {
+    'a': {'a': [1, 2, 3]},
+    'b': {'b': 'foo', 'c': 'bar'},
+    'c': {'c': [{'foo': 5, 'bar': 6, 'baz': [1, 2, 3]}]}
+}
+flatten(dic, root_keys_to_ignore={'b', 'c'})
+```
+returns:
+```python
+{
+    'a_a_0': 1,
+    'a_a_1': 2,
+    'a_a_2': 3
+}
+```
+This feature can prevent unnecessary processing which is a concern with deeply nested objects. 
+
+Thanks to [@mcarans](http://github.com/jvalhondo) and [@aquilax](http://github.com/drajen) for requesting and helping with fleshing out this feature.
+
+# unflatten
 Reverses the flattening process. Example usage:
 ```python
 from flatten_json import unflatten
@@ -134,4 +158,4 @@ returns:
 }
 ```
 
-Thanks to [@nmaas87](http://github.com/nmaas87) for requesting this feature.
+Thanks to [@nmaas87](http://github.com/nmaas87) for requesting this feature and [@aquilax](http://github.com/aquilax) for making it actually work.

--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ returns:
 Thanks to [@jvalhondo](http://github.com/jvalhondo), [@drajen](http://github.com/drajen), and [@azaitsev](http://github.com/azaitsev) for contributing to this feature.
 
 ### Ignore root keys
-By default `flatten` goes through all the keys in the object. If you are not interested in output from a set of keys you can pass this set as an argument to `root_keys_to_ignore`.:
-
+By default `flatten` goes through all the keys in the object. If you are not interested in output from a set of keys you can pass this set as an argument to `root_keys_to_ignore`:
 ```python
 dic = {
     'a': {'a': [1, 2, 3]},

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ dic = [
 ```
 We can apply `flatten` to each element in the array and then use pandas to capture the output as a dataframe:
 ```python
-dic_flattened = [flatten(d) for d in dic]
+dic_flattened = (flatten(d) for d in dic)
 ```
 which creates an array of flattened objects:
 ```python

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/amirziai/flatten.svg?branch=master)](https://travis-ci.org/amirziai/flatten) [![PyPI version](https://badge.fury.io/py/flatten_json.svg)](https://badge.fury.io/py/flatten_json)
 
 # flatten_json
-Flattens JSON objects in Python. ```flatten_json``` destroys the hierarchy in your object which can be useful if you want to force your objects into a table.
+Flattens JSON objects in Python. ```flatten_json``` flattens the hierarchy in your object which can be useful if you want to force your objects into a table.
 
 ### Installation
 ```

--- a/flatten_json.py
+++ b/flatten_json.py
@@ -17,29 +17,35 @@ def _construct_key(previous_key, separator, new_key):
         return new_key
 
 
-def flatten(nested_dict, separator="_"):
+def flatten(nested_dict, separator="_", root_keys_to_ignore=set()):
     """
     Flattens a dictionary with nested structure to a dictionary with no hierarchy
+    Consider ignoring keys that you are not interested in to prevent unnecessary processing
+    This is specially true for very deep objects
+
     :param nested_dict: dictionary we want to flatten
     :param separator: string to separate dictionary keys by
+    :param root_keys_to_ignore: set of root keys to ignore from flattening
     :return: flattened dictionary
     """
     assert isinstance(nested_dict, dict), "flatten requires a dictionary input"
     assert isinstance(separator, str), "separator must be a string"
 
-    # This global dictionary is recursively mutated and returned
+    # This global dictionary stores the flattened keys and values and is ultimately returned
     flattened_dict = dict()
 
     def _flatten(object_, key):
         """
-
+        For dict, list and set objects_ calls itself on the elements and for other types assigns the object_ to
+        the corresponding key in the global flattened_dict
         :param object_: object to flatten
         :param key: carries the concatenated key for the object_
         :return: None
         """
         if isinstance(object_, dict):
             for object_key in object_:
-                _flatten(object_[object_key], _construct_key(key, separator, object_key))
+                if not (not key and object_key in root_keys_to_ignore):
+                    _flatten(object_[object_key], _construct_key(key, separator, object_key))
         elif isinstance(object_, list) or isinstance(object_, set):
             for index, item in enumerate(object_):
                 _flatten(item, _construct_key(key, separator, index))
@@ -62,7 +68,7 @@ def _unflatten_asserts(flat_dict, separator):
 def unflatten(flat_dict, separator='_'):
     """
     Creates a hierarchical dictionary from a flattened dictionary
-    Assumes that no lists are present in the
+    Assumes no lists are present
     :param flat_dict: a dictionary with no hierarchy
     :param separator: a string that separates keys
     :return: a dictionary with hierarchy
@@ -86,8 +92,8 @@ def unflatten(flat_dict, separator='_'):
 
 def unflatten_list(flat_dict, separator='_'):
     """
-    Unflattens a dictionary, first assuming no lists exist and then tries to identify lists and replace them
-    This is probably not very inefficient and has not been tested extensively
+    Unflattens a dictionary, first assuming no lists exist and then tries to identify lists and replaces them
+    This is probably not very efficient and has not been tested extensively
     Feel free to add test cases or rewrite the logic
     Issues that stand out to me:
     - Sorting all the keys in the dictionary, which specially for the root dictionary can be a lot of keys
@@ -110,9 +116,12 @@ def unflatten_list(flat_dict, separator='_'):
             except (ValueError, TypeError):
                 keys = []
             keys_len = len(keys)
-            if (keys_len and sum(keys) == int(((keys_len - 1) * keys_len) / 2) and keys[0] == 0 and
+
+            if (keys_len > 0 and sum(keys) == int(((keys_len - 1) * keys_len) / 2) and keys[0] == 0 and
                     keys[-1] == keys_len - 1 and check_if_numbers_are_consecutive(keys)):
+                # The dictionary looks like a list so we're going to replace it as one
                 parent_object[parent_object_key] = [object_[str(key)] for key in keys]
+
             for key in object_:
                 if isinstance(object_[key], dict):
                     _convert_dict_to_list(object_[key], object_, key)

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -160,6 +160,21 @@ class UnitTests(unittest.TestCase):
         actual = unflatten_list(dic, ':')
         self.assertEqual(actual, expected)
 
+    def test_flatten_ignore_keys(self):
+        """Ignore a set of root keys for processing"""
+        dic = {
+            'a': {'a': [1, 2, 3]},
+            'b': {'b': 'foo', 'c': 'bar'},
+            'c': {'c': [{'foo': 5, 'bar': 6, 'baz': [1, 2, 3]}]}
+        }
+        expected = {
+            'a_a_0': 1,
+            'a_a_1': 2,
+            'a_a_2': 3
+        }
+        actual = flatten(dic, root_keys_to_ignore={'b', 'c'})
+        self.assertEqual(actual, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary
Adding an argument to `flatten` that takes a set of root keys to be ignored from the flattening process. @mcarans this PR addresses no. 4 on your list. Read the README file, comments in the code and test for more details. The thinking here is that we want the caller to be able to prevent extra processing that he/she's not interested in anyways. No. 3 on your list is a complement of this set, I decided that it's more intuitive to specify keys to ignore given the use case that I described but the opposite can be accomplished too. The other decision here is that only root keys are ignored, I think we do not want to expand this beyond root keys (or if we do it has to be a separate argument/function) since this can have unintended consequences. For example the key `id` could appear in many objects in the hierarchy and I can't think of a reason to systematically remove it. Regarding items 1 and 2 on your list I think the onus is on the caller to decide how to deal with the output since `flatten` is doing the processing so I decided not to include it for now. Regarding item 5 I think option (a) would break the contract since `flatten` is supposed to return a flat object and (b) is possible and I can see how it'd be used but I came up with another use case and I think I'm going to tackle them both cause they may have some interplay. The new use case is to provide a maximum depth. I'll create a new issue with item 5 and max depth once we're through with this feature.

### Bug Fixes/New Features
* New argument for `flatten` that allows for ignoring a set of root keys.

### How to Verify
Added a unit test.

### Side Effects
No

### Resolves
Partially addresses #9 

### Tests
New test passes

### Code Reviewer(s)
@mcarans @aquilax 