### PR TITLE
Fix utf8 issue

### DIFF
--- a/flatten_json.py
+++ b/flatten_json.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from collections import Iterable
 
 from util import check_if_numbers_are_consecutive

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name='flatten_json',
     packages=[''],
-    version='0.1.5',
+    version='0.1.6',
     description='Flatten JSON objects',
     author='Amir Ziai',
     author_email='arziai@gmail.com',

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import unittest
 
 from flatten_json import flatten, unflatten, unflatten_list
@@ -36,6 +39,15 @@ class UnitTests(unittest.TestCase):
     def test_one_flatten(self):
         dic = {'a': '1',
                'b': '2',
+               'c': {'c1': '3', 'c2': '4'}
+               }
+        expected = {'a': '1', 'b': '2', 'c_c1': '3', 'c_c2': '4'}
+        actual = flatten(dic)
+        self.assertEqual(actual, expected)
+
+    def test_one_flatten_utf8(self):
+        dic = {'a': '1',
+               'ñ': 'áéö',
                'c': {'c1': '3', 'c2': '4'}
                }
         expected = {'a': '1', 'b': '2', 'c_c1': '3', 'c_c2': '4'}

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -50,7 +50,7 @@ class UnitTests(unittest.TestCase):
                'ñ': 'áéö',
                'c': {'c1': '3', 'c2': '4'}
                }
-        expected = {'a': '1', 'b': '2', 'c_c1': '3', 'c_c2': '4'}
+        expected = {'a': '1', 'ñ': 'áéö', 'c_c1': '3', 'c_c2': '4'}
         actual = flatten(dic)
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
### Summary
When a dictionary or JSON object has keys or values in UTF8, the library fails, as it cannot encode it properly.

### Bug Fixes/New Features
* Enforce at the top of the file UTF8 so it handles it properly.

### How to Verify
There's a new test to verify that it can handle utf8 properly. Just use that test with the master branch and you will see the error.

### Side Effects
No.

### Resolves
Fixes UTF-8 Issues.

### Tests
This is the new test:  test_one_flatten_utf8()

### Code Reviewer(s)
@amirziai 