### PR TITLE
Command line invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,4 +157,15 @@ returns:
 }
 ```
 
+# Command line invocation
+This library can be used to flatten json read from standard input at the command line.
+```bash
+>>> echo '{"a": {"b": 1}}' | python -m flatten_json
+{"a_b": 1}
+
+>>> echo '{"a": {"b": 1}}' | flatten_json
+{"a_b": 1}%-
+```
+
+# Acknowledgements
 Thanks to [@nmaas87](http://github.com/nmaas87) for requesting this feature and [@aquilax](http://github.com/aquilax) for making it actually work.

--- a/flatten_json.py
+++ b/flatten_json.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import sys
 from collections import Iterable
 
 from util import check_if_numbers_are_consecutive
@@ -131,3 +132,12 @@ def unflatten_list(flat_dict, separator='_'):
 
     _convert_dict_to_list(unflattened_dict, None, None)
     return unflattened_dict
+
+def cli(input_stream=sys.stdin, output_stream=sys.stdout):
+    import json
+    raw = input_stream.read()
+    input_json = json.loads(raw)
+    json.dump(flatten(input_json), output_stream)
+
+if __name__ == '__main__':
+    cli()

--- a/flatten_json.py
+++ b/flatten_json.py
@@ -137,7 +137,8 @@ def cli(input_stream=sys.stdin, output_stream=sys.stdout):
     import json
     raw = input_stream.read()
     input_json = json.loads(raw)
-    json.dump(flatten(input_json), output_stream)
+    output = json.dumps(flatten(input_json))
+    output_stream.write(output)
 
 if __name__ == '__main__':
     cli()

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='flatten_json',
-    packages=[''],
+    modules=['flatten_json'],
     version='0.1.6',
     description='Flatten JSON objects',
     author='Amir Ziai',
@@ -10,4 +10,7 @@ setup(
     url='https://github.com/amirziai/flatten',
     keywords=['json', 'flatten', 'pandas'],
     classifiers=[],
+    entry_points={
+        'console_scripts': ['flatten_json=flatten_json:cli']
+    },
 )

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -2,8 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import json
+from io import StringIO
 
-from flatten_json import flatten, unflatten, unflatten_list
+from flatten_json import flatten, unflatten, unflatten_list, cli
 from util import check_if_numbers_are_consecutive
 
 
@@ -186,6 +188,13 @@ class UnitTests(unittest.TestCase):
         }
         actual = flatten(dic, root_keys_to_ignore={'b', 'c'})
         self.assertEqual(actual, expected)
+
+    def test_command_line(self):
+        input_stream = StringIO(u'{"a": {"b": 1}}')
+        output_stream = StringIO()
+        cli(input_stream, output_stream)
+        output = output_stream.getvalue()
+        json.loads(output)
 
 
 if __name__ == '__main__':

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -197,7 +197,8 @@ class UnitTests(unittest.TestCase):
         output_stream = StringIO()
         cli(input_stream, output_stream)
         output = output_stream.getvalue()
-        json.loads(output)
+        result = json.loads(output)
+        self.assertEqual(result, dict(a_b=1))
 
 
 if __name__ == '__main__':

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -3,7 +3,10 @@
 
 import unittest
 import json
-from io import StringIO
+try:
+    from StringIO import StringIO
+except:
+    from io import StringIO
 
 from flatten_json import flatten, unflatten, unflatten_list, cli
 from util import check_if_numbers_are_consecutive

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -4,8 +4,10 @@
 import unittest
 import json
 try:
+    # python2
     from StringIO import StringIO
-except:
+except ImportError:
+    # python3
     from io import StringIO
 
 from flatten_json import flatten, unflatten, unflatten_list, cli


### PR DESCRIPTION
 - Use setuptools for develop command and console entrypoints
 - Make `python -m flatten_json` work
 - Create a command line entrypoint `flatten_json`

### Summary

-  Use setuptools for develop command and console entrypoints
 - Make `python -m flatten_json` work
 - Create a command line entrypoint `flatten_json`

### Bug Fixes/New Features

- Use setuptools for develop command and console entrypoints
 - Make `python -m flatten_json` work
 - Create a command line entrypoint `flatten_json`

### How to Verify
 > How can reviewers verify the request has the intended effect? 

Look at documentation of new features added to readme. Run this documentation.

> This should include descriptions of any new tests that are added or old tests that are updated. 

See `git log`. consider running `git diff origin/master..HEAD test_flatten.py`  :P

There is a test of the command line feature in the tests file that passes. Thought as this code is all basically plumbing and glue this doesn't really test that much.

How code was tested
```
python setup.py develop
python3 setup.py develop
python -m nose
python3 -m nose
cat README.md | grep echo | cut -b 5- | sed "s/python/python3/" | bash
```

### Side Effects

We change to using setuptools. In theory this increases the number of dependencies.
A json dependecy is added to the tests.
The use of setuptools is pervasive.

### Resolves
Nothing

### Tests
What tests were created or changed for this feature or fix? Do all tests pass, and if not, why?

### Code Reviewer(s)
None?