### PR TITLE
Improve UTF8 handling

### DIFF
--- a/flatten_json.py
+++ b/flatten_json.py
@@ -16,7 +16,11 @@ def _construct_key(previous_key, separator, new_key):
     :return: a string if previous_key exists and simply passes through the new_key otherwise
     """
     if previous_key:
-        return "{}{}{}".format(previous_key, separator, new_key)
+        if (type(previous_key) is unicode or type(separator) is unicode or
+            type(new_key) is unicode):
+            return u"{}{}{}".format(previous_key, separator, new_key)
+        else:
+            return "{}{}{}".format(previous_key, separator, new_key)
     else:
         return new_key
 

--- a/flatten_json.py
+++ b/flatten_json.py
@@ -16,11 +16,7 @@ def _construct_key(previous_key, separator, new_key):
     :return: a string if previous_key exists and simply passes through the new_key otherwise
     """
     if previous_key:
-        if (type(previous_key) is unicode or type(separator) is unicode or
-            type(new_key) is unicode):
-            return u"{}{}{}".format(previous_key, separator, new_key)
-        else:
-            return "{}{}{}".format(previous_key, separator, new_key)
+        return u"{}{}{}".format(previous_key, separator, new_key)
     else:
         return new_key
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='flatten_json',
     modules=['flatten_json'],
-    version='0.1.6',
+    version='0.1.7',
     description='Flatten JSON objects',
     author='Amir Ziai',
     author_email='arziai@gmail.com',

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -54,12 +54,20 @@ class UnitTests(unittest.TestCase):
 
     def test_one_flatten_utf8(self):
         dic = {'a': '1',
-               'ñ': 'áéö',
-               'c': {'c1': '3', 'c2': '4'}
+               u'ñ': u'áéö',
+               'c': {u'c1': '3', 'c2': '4'}
                }
-        expected = {'a': '1', 'ñ': 'áéö', 'c_c1': '3', 'c_c2': '4'}
+        expected = {'a': '1', u'ñ': u'áéö', 'c_c1': '3', 'c_c2': '4'}
         actual = flatten(dic)
         self.assertEqual(actual, expected)
+
+    def test_one_flatten_utf8_dif(self):
+        a = {u'eñe': 1}
+        info = dict(info=a)
+        expected = {u'info_{}'.format(u'eñe'): 1}
+        actual = flatten(info)
+        self.assertEqual(actual, expected)
+
 
     def test_custom_separator(self):
         dic = {'a': '1',


### PR DESCRIPTION
### Summary
While we fixed the issue for UTF8, there stills a problem when we have mixed strings and UTF8 cases. When we have  for example the following data:

```python
a = {u'eñe': 1}
info = dict(info=a)
flatten(info)
return "{}{}{}".format(previous_key, separator, new_key)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf1' in position 1: ordinal not in range(128)
```
### Bug Fixes/New Features
* check for utf8 and use u"{}{}{}".format to transform everything to utf8.

### How to Verify
I've added a specific test for this case. 

### Side Effects
Nope

### Tests
test_one_flatten_utf8_dif <- the new test

### Code Reviewer(s)
