### PR TITLE
Fix for issue 31

### DIFF
--- a/flatten_json.py
+++ b/flatten_json.py
@@ -132,11 +132,11 @@ def unflatten_list(flat_dict, separator='_'):
     unflattened_dict = unflatten(flat_dict, separator)
 
     def _convert_dict_to_list(object_, parent_object, parent_object_key):
-       for key in object_:
-           if isinstance(object_[key], dict):
-               _convert_dict_to_list(object_[key], object_, key)
+        for key in object_:
+            if isinstance(object_[key], dict):
+                _convert_dict_to_list(object_[key], object_, key)
 
-       if isinstance(object_, dict):
+        if isinstance(object_, dict):
             try:
                 keys = [int(key) for key in object_]
                 keys.sort()

--- a/flatten_json.py
+++ b/flatten_json.py
@@ -132,11 +132,10 @@ def unflatten_list(flat_dict, separator='_'):
     unflattened_dict = unflatten(flat_dict, separator)
 
     def _convert_dict_to_list(object_, parent_object, parent_object_key):
-        for key in object_:
-            if isinstance(object_[key], dict):
-                _convert_dict_to_list(object_[key], object_, key)
-
         if isinstance(object_, dict):
+            for key in object_:
+                if isinstance(object_[key], dict):
+                    _convert_dict_to_list(object_[key], object_, key)
             try:
                 keys = [int(key) for key in object_]
                 keys.sort()

--- a/flatten_json.py
+++ b/flatten_json.py
@@ -132,7 +132,11 @@ def unflatten_list(flat_dict, separator='_'):
     unflattened_dict = unflatten(flat_dict, separator)
 
     def _convert_dict_to_list(object_, parent_object, parent_object_key):
-        if isinstance(object_, dict):
+       for key in object_:
+           if isinstance(object_[key], dict):
+               _convert_dict_to_list(object_[key], object_, key)
+
+       if isinstance(object_, dict):
             try:
                 keys = [int(key) for key in object_]
                 keys.sort()
@@ -154,10 +158,6 @@ def unflatten_list(flat_dict, separator='_'):
                     _convert_dict_to_list(parent_object[parent_object_key][-1],
                                           parent_object[parent_object_key],
                                           key_index)
-
-            for key in object_:
-                if isinstance(object_[key], dict):
-                    _convert_dict_to_list(object_[key], object_, key)
 
     _convert_dict_to_list(unflattened_dict, None, None)
     return unflattened_dict

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -223,12 +223,10 @@ class UnitTests(unittest.TestCase):
 
     def test_unflatten_with_list_issue31(self):
         """https://github.com/amirziai/flatten/issues/31"""
-        dic = {"testdict": { 
-                   "seconddict": [
-                       [ "firstvalue",
-                         "secondvalue" ],
-                       [ "thirdvalue",
-                         "fourthvalue" ]]}}
+        dic = {"testdict": {"seconddict": [["firstvalue",
+                                            "secondvalue"],
+                                           ["thirdvalue",
+                                            "fourthvalue"]]}}
 
         dic_flatten = flatten(dic)
         actual = unflatten_list(dic_flatten)

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -221,6 +221,19 @@ class UnitTests(unittest.TestCase):
         actual = unflatten_list(dic_flatten)
         self.assertEqual(actual, dic)
 
+    def test_unflatten_with_list_issue31(self):
+        """https://github.com/amirziai/flatten/issues/31"""
+        dic = {"testdict": { 
+                   "seconddict": [
+                       [ "firstvalue",
+                         "secondvalue" ],
+                       [ "thirdvalue",
+                         "fourthvalue" ]]}}
+
+        dic_flatten = flatten(dic)
+        actual = unflatten_list(dic_flatten)
+        self.assertEqual(actual, dic)
+
     def test_unflatten_with_list_deep(self):
         dic = {'a': [
             {'b': [{'c': [{'a': 5, 'b': {'a': [1, 2, 3]}, 'c': {'x': 3}}]}]}]}


### PR DESCRIPTION
### Summary
This resolves issue 31 by going depth-first rather than breadth-first in walking the tree of dictionaries

### Bug Fixes/New Features
* Resolves issue 31

### How to Verify
Utilize input data of the format:
```
{ "somedict/anotherdict/0/0": "firstvalue",
  "somedict/anotherdict/0/1": "secondvalue",
  "somedict/anotherdict/1/0": "thirdvalue",
  "somedict/anotherdict/1/1": "fourthvalue" }
```

This should result in the below output after using `unflatten_list()`
```
{ "somedict": {
        "anotherdict": [ 
         [   "firstvalue",
            "secondvalue" ],
         [  "thirdvalue",
            "fourthvalue" ] ]
  }
}
```
### Side Effects
No known side effects
### Resolves
Fixes issue #31 

### Tests
No changed tests, does resolve failure testing with above values.

### Code Reviewer(s)
No code reviewers