### PR TITLE
Fix warning re upcoming deprecation of `from collections import Iterable`

### DIFF
--- a/flatten_json.py
+++ b/flatten_json.py
@@ -3,7 +3,11 @@
 
 import sys
 import json
-from collections import Iterable
+try:
+    # 3.8 and up
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from util import check_if_numbers_are_consecutive
 import six


### PR DESCRIPTION
No expected behavior change today, just future proofing for Python 3.8 and onwards:

In Python 3.7.1 (and presumably others) the warning is:

```
flatten_json.py:6
  flatten_json.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Iterable

-- Docs: https://docs.pytest.org/en/latest/warnings.html```