### PR TITLE
Make tuple treated the same as list and set

### DIFF
--- a/flatten_json.py
+++ b/flatten_json.py
@@ -68,7 +68,7 @@ def flatten(nested_dict, separator="_", root_keys_to_ignore=set()):
                     _flatten(object_[object_key], _construct_key(key,
                                                                  separator,
                                                                  object_key))
-        elif isinstance(object_, list) or isinstance(object_, set):
+        elif isinstance(object_, list) or isinstance(object_, set) or isinstance(object_, tuple):
             for index, item in enumerate(object_):
                 _flatten(item, _construct_key(key, separator, index))
         # Anything left take as is

--- a/flatten_json.py
+++ b/flatten_json.py
@@ -68,7 +68,7 @@ def flatten(nested_dict, separator="_", root_keys_to_ignore=set()):
                     _flatten(object_[object_key], _construct_key(key,
                                                                  separator,
                                                                  object_key))
-        elif isinstance(object_, list) or isinstance(object_, set) or isinstance(object_, tuple):
+        elif isinstance(object_, (list, set, tuple)):
             for index, item in enumerate(object_):
                 _flatten(item, _construct_key(key, separator, index))
         # Anything left take as is

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -111,7 +111,7 @@ class UnitTests(unittest.TestCase):
                     'e_0_g_0_j': '', 'e_0_g_0_k': None}
         actual = flatten(dic)
         self.assertEqual(actual, expected)
-    
+
     def test_tuple(self):
         dic = {
             'a': 1,

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -111,6 +111,24 @@ class UnitTests(unittest.TestCase):
                     'e_0_g_0_j': '', 'e_0_g_0_k': None}
         actual = flatten(dic)
         self.assertEqual(actual, expected)
+    
+    def test_tuple(self):
+        dic = {
+            'a': 1,
+            'b': ({'c': (2, 3)},)
+        }
+        expected = {'a': 1, 'b_0_c_0': 2, 'b_0_c_1': 3}
+        actual = flatten(dic)
+        self.assertEqual(actual, expected)
+
+    def test_empty_tuple(self):
+        dic = {
+            'a': 1,
+            'b': ({'c': ()},)
+        }
+        expected = {'a': 1, 'b_0_c': ()}
+        actual = flatten(dic)
+        self.assertEqual(actual, expected)
 
     def test_blog_example(self):
         dic = {


### PR DESCRIPTION
### Summary
Treats tuple the same as list and set in the flatten conversion. Also adds in two tests to prevent regression. Also collapses the `or` chain on the `isinstance` call for increased readability and ease of additions/subtractions.

### Bug Fixes/New Features
* Adds tuple to the structures flatten can support

### How to Verify
Added two tests to verify:
- A tuple with 1 or more values is expanded to its enumerated form: `test_tuple`
- An empty tuple is left as an empty tuple and not expanded further `test_empty_tuple`

### Side Effects
None

### Resolves
None

### Tests
All tests pass along with the two added tests: `test_tuple` and `test_empty_tuple`

### Code Reviewer(s)
@amirziai 