### PR TITLE
Add 'install_requires=['six']' to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,5 @@ setup(
     entry_points={
         'console_scripts': ['flatten_json=flatten_json:cli']
     },
+    install_requires=['six'],
 )


### PR DESCRIPTION
Your setup.py missed one line, `install_requires=['six']`. :smile: