### PR TITLE
Fix data loss when a root key contains another root key

### DIFF
--- a/flatten_json/__init__.py
+++ b/flatten_json/__init__.py
@@ -335,7 +335,9 @@ def unflatten(flat_dict, separator='_'):
     list_keys = sorted(flat_dict.keys())
     for i, item in enumerate(list_keys):
         if i != len(list_keys) - 1:
-            if not list_keys[i + 1].startswith(list_keys[i]):
+            split_key = item.split(separator)
+            next_split_key = list_keys[i + 1].split(separator)
+            if not split_key == next_split_key[:-1]:
                 _unflatten(unflattened_dict, item.split(separator),
                            flat_dict[item])
             else:

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -267,6 +267,22 @@ class UnitTests(unittest.TestCase):
         actual = unflatten(dic, '.')
         self.assertEqual(actual, expected)
 
+    def test_unflatten_with_key_loss_issue51(self):
+        """https://github.com/amirziai/flatten/issues/51"""
+        dic = {
+            'a': 1,
+            'a_b': 2,
+            'a_c.d': 3,
+            'a_c.e': 4
+        }
+        expected = {
+            'a': 1,
+            'a_b': 2,
+            'a_c': {'d': 3, 'e': 4}
+        }
+        actual = unflatten(dic, '.')
+        self.assertEqual(actual, expected)
+
     def test_flatten_preserve_lists_issue43_nested(self):
         """https://github.com/amirziai/flatten/issues/43"""
         dic = {


### PR DESCRIPTION
### Summary
Fix the issue where a root key is lost if another root key contains it.

### How to Verify
New test in `test_flatten.py`: `test_unflatten_with_key_loss_issue51`

### Side Effects
No.

### Resolves
Fixes https://github.com/amirziai/flatten/issues/51

### Tests
New test in `test_flatten.py`: `test_unflatten_with_key_loss_issue51`
All tests pass.

### Code Reviewer(s)
@amirziai