### PR TITLE
Replace separators found within keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ flatten(dic)
 
 Results:
 ```python
-{'a': '1',
- 'b': '2',
- 'c_0_d_0': '2',
- 'c_0_d_1': '3',
- 'c_0_d_2': '4',
- 'c_0_e_0_f': '1',
- 'c_0_e_0_g': '2'}
+{'a': 1,
+ 'b': 2,
+ 'c_0_d_0': 2,
+ 'c_0_d_1': 3,
+ 'c_0_d_2': 4,
+ 'c_0_e_0_f': 1,
+ 'c_0_e_0_g': 2}
 ```
 
 ### Usage with Pandas
@@ -51,9 +51,9 @@ dic_flattened = (flatten(d) for d in dic)
 ```
 which creates an array of flattened objects:
 ```python
-[{'a': '1', 'b': '2', 'c_d': '3', 'c_e': '4'},
- {'a': '0.5', 'c_d': '3.2'},
- {'a': '0.8', 'b': '1.8'}]
+[{'a': 1, 'b': 2, 'c_d': 3, 'c_e': 4},
+ {'a': 0.5, 'c_d': 3.2},
+ {'a': 0.8, 'b': 1.8}]
 ```
 Finally you can use ```pd.DataFrame``` to capture the flattened array:
 ```python

--- a/test_flatten.py
+++ b/test_flatten.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import unittest
 import json
+import unittest
+
+from flatten_json import (cli, flatten, flatten_preserve_lists, unflatten,
+                          unflatten_list)
+from flatten_json.util import check_if_numbers_are_consecutive
 
 try:
     # python2
@@ -11,9 +15,6 @@ except ImportError:
     # python3
     from io import StringIO
 
-from flatten_json import flatten, flatten_preserve_lists, unflatten, \
-    unflatten_list, cli
-from flatten_json.util import check_if_numbers_are_consecutive
 
 
 class UnitTests(unittest.TestCase):
@@ -2178,6 +2179,55 @@ class UnitTests(unittest.TestCase):
         output = output_stream.getvalue()
         result = json.loads(output)
         self.assertEqual(result, dict(a_b=1))
+
+    def test_replace_separators_none(self):
+        dic = {
+            'a_with_separator': {'b': [1, 2, 3]},
+        }
+        expected = {
+            'a_with_separator_b_0': 1,
+            'a_with_separator_b_1': 2,
+            'a_with_separator_b_2': 3
+        }
+        actual = flatten(dic)
+        self.assertEqual(actual, expected)
+
+    def test_replace_separators_remove(self):
+        dic = {
+            'a_with_separator': {'b': [1, 2, 3]},
+        }
+        expected = {
+            'awithseparator_b_0': 1,
+            'awithseparator_b_1': 2,
+            'awithseparator_b_2': 3
+        }
+        actual = flatten(dic, replace_separators='')
+        self.assertEqual(actual, expected)
+
+    def test_replace_separators_something(self):
+        dic = {
+            'a_with_separator': {'b': [1, 2, 3]},
+        }
+        expected = {
+            'a.with.separator_b_0': 1,
+            'a.with.separator_b_1': 2,
+            'a.with.separator_b_2': 3
+        }
+        actual = flatten(dic, replace_separators='.')
+        self.assertEqual(actual, expected)
+
+    def test_replace_separators_nested(self):
+        dic = {
+            'a_with_separator': {'b_with_separator': [1, 2, 3]},
+        }
+        expected = {
+            'awithseparator_bwithseparator_0': 1,
+            'awithseparator_bwithseparator_1': 2,
+            'awithseparator_bwithseparator_2': 3
+        }
+        actual = flatten(dic, replace_separators='')
+        self.assertEqual(actual, expected)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary
Separators that already exist within keys pose a risk when unpacking. This PR adds optional ability to replace separators found in keys with some other character

Also fixes some small typo in README.md

### Bug Fixes/New Features
* New parameter: replace_separators=None
* Fixes in README.md for example flattened values not being correct

### How to Verify
New tests: test_replace_separators_*

### Side Effects
Does the pull request contain any side effects? This should list non-obvious things that have
changed in the request.

### Resolves
Helps with https://github.com/amirziai/flatten/issues/60

### Tests
New tests: test_replace_separators_*
All tests passing

### Code Reviewer(s)
@amir-ziai-zefr 